### PR TITLE
modify makefile for OSX Pd builds

### DIFF
--- a/makefile.conf.in
+++ b/makefile.conf.in
@@ -230,6 +230,7 @@ endif
 ifeq ($(BUILDTYPE), PD)
 	ARCHFLAGS += -DEMBEDDED -DPD -I$(PD_INCLUDES)
 	ifeq ($(ARCH),MACOSX)
+		SHARED_LDFLAGS += -Wl,-U,_post
 		ARCHFLAGS += -arch i386 -arch x86_64
 	endif
 	ifndef RTLIBTYPE
@@ -300,7 +301,11 @@ endif
 ifeq ($(ARCH),MACOSX)
   SYS_LDFLAGS = -framework CoreAudio $(ARCH_SYS_LDFLAGS)
   DSO_LDFLAGS = $(SYS_LDFLAGS)
-  SHARED_LDFLAGS = $(ARCHFLAGS) -bundle -Wl,-U,_post
+  ifeq ($(BUILDTYPE), PD)
+  	SHARED_LDFLAGS = $(ARCHFLAGS) -bundle
+  else
+    	SHARED_LDFLAGS = $(ARCHFLAGS) -bundle -flat_namespace -undefined suppress
+  endif
   DYNAMIC_LDFLAGS = $(ARCHFLAGS) -flat_namespace -undefined suppress -dynamiclib -install_name $(LIBDIR)/$(RTLIB)
   DYN = 
 endif

--- a/makefile.conf.in
+++ b/makefile.conf.in
@@ -229,6 +229,9 @@ endif
 # -- Pd -----------------------------------------------------
 ifeq ($(BUILDTYPE), PD)
 	ARCHFLAGS += -DEMBEDDED -DPD -I$(PD_INCLUDES)
+	ifeq ($(ARCH),MACOSX)
+		ARCHFLAGS += -arch i386 -arch x86_64
+	endif
 	ifndef RTLIBTYPE
 		RTLIBTYPE = DYNAMIC
 	endif
@@ -297,7 +300,7 @@ endif
 ifeq ($(ARCH),MACOSX)
   SYS_LDFLAGS = -framework CoreAudio $(ARCH_SYS_LDFLAGS)
   DSO_LDFLAGS = $(SYS_LDFLAGS)
-  SHARED_LDFLAGS = $(ARCHFLAGS) -bundle -flat_namespace -undefined suppress
+  SHARED_LDFLAGS = $(ARCHFLAGS) -bundle -Wl,-U,_post
   DYNAMIC_LDFLAGS = $(ARCHFLAGS) -flat_namespace -undefined suppress -dynamiclib -install_name $(LIBDIR)/$(RTLIB)
   DYN = 
 endif


### PR DESCRIPTION
Remove flat_namespace from OSX shared LD flags and add i386 and x86_64 arch flags.